### PR TITLE
Explicitly declaring css height for snippet icons.

### DIFF
--- a/snippets/base/models.py
+++ b/snippets/base/models.py
@@ -325,8 +325,9 @@ class Snippet(CachingMixin, SnippetBaseModel):
     exclude_from_search_providers = models.ManyToManyField(
         'SearchProvider', blank=True, verbose_name='Excluded Search Providers')
 
-    campaign = models.CharField(max_length=255, blank=True, default='',
-                                help_text='Optional campaign name. Will be added in the stats ping.')
+    campaign = models.CharField(
+        max_length=255, blank=True, default='',
+        help_text='Optional campaign name. Will be added in the stats ping.')
     created = models.DateTimeField(auto_now_add=True)
     modified = models.DateTimeField(auto_now=True)
 

--- a/snippets/base/static/css/templateDataWidget.css
+++ b/snippets/base/static/css/templateDataWidget.css
@@ -45,6 +45,7 @@
 .template-data-widget img {
     display: inline-block;
     border: 1px solid #DDD;
+    height: 50px;
 }
 
 .snippet-preview-container {

--- a/snippets/base/templates/base/includes/snippet_css.html
+++ b/snippets/base/templates/base/includes/snippet_css.html
@@ -1,36 +1,37 @@
 <style type="text/css">
-#snippetContainer div.snippet {
-  display: none;
-}
-
-#snippetContainer div.snippet img.icon {
-  margin: -0.75em 1em 0 0;
-  float: left;
-}
-
-{% if client and client.startpage_version > 1 %}
-  .snippet {
-    position: relative;
-  }
-
-  .snippet .icon {
-    position: absolute;
-    right: 400px;
-    top: 5px;
-  }
-
-  .snippet p {
-    display: table-cell;
-    height: 40px;
-    padding-left: 80px;
-    vertical-align: middle;
-    width: 400px;
-  }
-{% endif %}
-
-{% if preview %}
- #searchContainer form {
-     margin-bottom: 0px;
+ #snippetContainer div.snippet {
+     display: none;
  }
-{% endif %}
+
+ #snippetContainer div.snippet img.icon {
+     margin: -0.75em 1em 0 0;
+     float: left;
+ }
+
+ {% if client and client.startpage_version > 1 %}
+   .snippet {
+       position: relative;
+   }
+
+   .snippet .icon {
+       position: absolute;
+       right: 400px;
+       top: 5px;
+       height: 50px;
+   }
+
+   .snippet p {
+       display: table-cell;
+       height: 40px;
+       padding-left: 80px;
+       vertical-align: middle;
+       width: 400px;
+   }
+ {% endif %}
+
+ {% if preview %}
+   #searchContainer form {
+       margin-bottom: 0px;
+   }
+ {% endif %}
 </style>

--- a/snippets/base/tests/test_models.py
+++ b/snippets/base/tests/test_models.py
@@ -163,14 +163,28 @@ class SnippetTests(TestCase):
         snippet = SnippetFactory.create(template=template, data=data,
                                         countries=['us'], weight=60)
 
-        expected = ('<div data-snippet-id="{id}" data-weight="60" class="snippet-metadata" '
-                    'data-countries="us"><a href="asdf">qwer</a></div>'.format(id=snippet.id))
+        expected = ('<div data-snippet-id="{id}" data-weight="60" data-campaign="" '
+                    'class="snippet-metadata" data-countries="us">'
+                    '<a href="asdf">qwer</a></div>'.format(id=snippet.id))
         eq_(snippet.render().strip(), expected)
         template.render.assert_called_with({
             'url': 'asdf',
             'text': 'qwer',
             'snippet_id': snippet.id
         })
+
+    def test_render_campaign(self):
+        template = SnippetTemplateFactory.create()
+        template.render = Mock()
+        template.render.return_value = '<a href="asdf">qwer</a>'
+
+        data = '{"url": "asdf", "text": "qwer"}'
+        snippet = SnippetFactory.create(template=template, data=data, campaign='foo')
+
+        expected = ('<div data-snippet-id="{id}" data-weight="100" '
+                    'data-campaign="foo" class="snippet-metadata">'
+                    '<a href="asdf">qwer</a></div>'.format(id=snippet.id))
+        eq_(snippet.render().strip(), expected)
 
     def test_render_no_country(self):
         """
@@ -184,7 +198,8 @@ class SnippetTests(TestCase):
         data = '{"url": "asdf", "text": "qwer"}'
         snippet = SnippetFactory.create(template=template, data=data)
 
-        expected = ('<div data-snippet-id="{0}" data-weight="100" class="snippet-metadata">'
+        expected = ('<div data-snippet-id="{0}" data-weight="100" '
+                    'data-campaign="" class="snippet-metadata">'
                     '<a href="asdf">qwer</a></div>'
                     .format(snippet.id))
         eq_(snippet.render().strip(), expected)
@@ -201,7 +216,7 @@ class SnippetTests(TestCase):
         snippet = SnippetFactory.create(template=template, data=data, countries=['us', 'el'])
 
         expected = (
-            '<div data-snippet-id="{0}" data-weight="100" '
+            '<div data-snippet-id="{0}" data-weight="100" data-campaign="" '
             'class="snippet-metadata" data-countries="us,el">'
             '<a href="asdf">qwer</a></div>'.format(snippet.id))
         eq_(snippet.render().strip(), expected)
@@ -220,7 +235,7 @@ class SnippetTests(TestCase):
         search_providers = SearchProviderFactory.create_batch(2)
         snippet.exclude_from_search_providers.add(*search_providers)
 
-        expected = ('<div data-snippet-id="{id}" data-weight="100" '
+        expected = ('<div data-snippet-id="{id}" data-weight="100" data-campaign="" '
                     'class="snippet-metadata" data-exclude-from-search-engines="{engines}">'
                     '<a href="asdf">qwer</a></div>'.format(
                         id=snippet.id,


### PR DESCRIPTION
Don't allow SVG icons get larger than 40x50px by explicitly declaring
their height.