### PR TITLE
Cache bundles for a month.

### DIFF
--- a/media/bundles/.htaccess
+++ b/media/bundles/.htaccess
@@ -1,0 +1,4 @@
+ExpiresActive on
+ExpiresDefault "access plus 1 month"
+FileETag MTime
+Header set Access-Control-Allow-Origin "*"

--- a/snippets/base/models.py
+++ b/snippets/base/models.py
@@ -107,7 +107,8 @@ class SnippetBundle(object):
         # Key should consist of snippets that are in the bundle plus any
         # properties of the client that may change the snippet code
         # being sent.
-        key_properties = [snippet.id for snippet in self.snippets]
+        key_properties = ['{id}-{date}'.format(id=snippet.id, date=snippet.modified.isoformat())
+                          for snippet in self.snippets]
         key_properties.extend([
             self.client.startpage_version,
             self.client.locale,


### PR DESCRIPTION
Bundle filename is calculated based on snippet id and snippet modified date. Thus if contents change the bundle filename changes too. By instructing the browser to cache the bundle for a month we reduce the traffic transferred in the case where bundles do not change between the 4 hour intervals or for a day or two.

We still keep the `settings.SNIPPET_BUNDLE_TIMEOUT` setting of the `fetch_pregenerated_snippets` view, which means that the browser will try to get new snippets after `settings.SNIPPET_BUNDLE_TIMEOUT` and in the case that the bundle hasn't changed it will be redirected to something already cached.