### PR TITLE
Send custom metric if it exists.

### DIFF
--- a/snippets/base/templates/base/includes/snippet_js.html
+++ b/snippets/base/templates/base/includes/snippet_js.html
@@ -454,6 +454,8 @@ Mozilla.UITour.setConfiguration = function(configName, configValue) {
         // Count snippet clicks.
         if (target && target.href && target.dataset.eventCounted !== 'true') {
             target.dataset.eventCounted = 'true';
+            // Fetch custom metric or default to 'click'
+            var metric = target.dataset.metric || 'click';
 
             // If user is not opening a new tab, preventDefault action.
             if (event.button === 0 && !(event.metaKey || event.ctrlKey)) {
@@ -463,7 +465,7 @@ Mozilla.UITour.setConfiguration = function(configName, configValue) {
                 }
             }
 
-            sendMetric('click', callback);
+            sendMetric(metric, callback);
         }
 
         // Handle about:accounts clicks.


### PR DESCRIPTION
If clicked link has data-metric attrib use that to name the metric, else
default to 'click'.