### PR TITLE
Isolate snippet code

### DIFF
--- a/snippets/base/helpers.py
+++ b/snippets/base/helpers.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 
+from django.template.defaultfilters import escapejs_filter
+
 from jingo import register
 
 
@@ -22,3 +24,7 @@ def humanize(date):
     if isinstance(date, datetime):
         return date.strftime('%a %d %b %Y, %H:%M UTC')
     return None
+
+@register.filter
+def escapejs(data):
+    return escapejs_filter(data)

--- a/snippets/base/helpers.py
+++ b/snippets/base/helpers.py
@@ -25,6 +25,7 @@ def humanize(date):
         return date.strftime('%a %d %b %Y, %H:%M UTC')
     return None
 
+
 @register.filter
 def escapejs(data):
     return escapejs_filter(data)

--- a/snippets/base/templates/base/fetch_snippets.html
+++ b/snippets/base/templates/base/fetch_snippets.html
@@ -1,7 +1,5 @@
-<div class="snippet_set" id="snippet_set" data-locale="{{ locale }}">
-  {% include 'base/includes/snippet_css.html' %}
-  {% for snippet in snippets %}
-    {{ snippet.render() }}
-  {% endfor %}
-  {% include 'base/includes/snippet_js.html' %}
-</div>
+{% include 'base/includes/snippet_css.html' %}
+<script type="text/javascript">
+  var ABOUTHOME_SNIPPETS = {{ snippets_json }};
+</script>
+{% include 'base/includes/snippet_js.html' %}

--- a/snippets/base/templates/base/fetch_snippets.html
+++ b/snippets/base/templates/base/fetch_snippets.html
@@ -1,5 +1,5 @@
 {% include 'base/includes/snippet_css.html' %}
 <script type="text/javascript">
-  var ABOUTHOME_SNIPPETS = {{ snippets_json }};
+  var ABOUTHOME_SNIPPETS = JSON.parse('{{ snippets_json|escapejs|safe }}');
 </script>
 {% include 'base/includes/snippet_js.html' %}

--- a/snippets/base/templates/base/includes/snippet_css.html
+++ b/snippets/base/templates/base/includes/snippet_css.html
@@ -1,12 +1,8 @@
 <style type="text/css">
- #snippetContainer div.snippet {
-     display: none;
- }
-
- #snippetContainer div.snippet img.icon {
-     margin: -0.75em 1em 0 0;
-     float: left;
- }
+#snippetContainer div.snippet img.icon {
+  margin: -0.75em 1em 0 0;
+  float: left;
+}
 
  {% if client and client.startpage_version > 1 %}
    .snippet {

--- a/snippets/base/templates/base/includes/snippet_js.html
+++ b/snippets/base/templates/base/includes/snippet_js.html
@@ -101,6 +101,7 @@ Mozilla.UITour.setConfiguration = function(configName, configValue) {
 };
 // End MozUITour
 
+
 (function(showDefaultSnippets) {
     'use strict';
 
@@ -190,7 +191,7 @@ Mozilla.UITour.setConfiguration = function(configName, configValue) {
             var topSection = document.getElementById('topSection');
             // Add sample rate and snippet ID to currently displayed links.
             var parameters = ('sample_rate=' + SNIPPET_METRICS_SAMPLE_RATE + '&snippet_name=' +
-                              show_snippet_id);
+                              ABOUTHOME_SHOWN_SNIPPET.id);
             modifyLinks(topSection.querySelectorAll('a'), parameters);
             addSnippetBlockLinks(topSection.querySelectorAll('.block-snippet-button'));
         });

--- a/snippets/base/templates/base/includes/snippet_js.html
+++ b/snippets/base/templates/base/includes/snippet_js.html
@@ -10,8 +10,8 @@
 
 
 'use strict';
-var SNIPPET_METRICS_SAMPLE_RATE = 0.1;
-var SNIPPET_METRICS_URL = 'https://snippets-stats.mozilla.org/foo.html';
+var SNIPPET_METRICS_SAMPLE_RATE = {{ settings.METRICS_SAMPLE_RATE }};
+var SNIPPET_METRICS_URL = '{{ settings.METRICS_URL }}';
 var ABOUTHOME_SHOWN_SNIPPET = null;
 
 
@@ -105,7 +105,7 @@ Mozilla.UITour.setConfiguration = function(configName, configValue) {
 (function(showDefaultSnippets) {
     'use strict';
 
-    var GEO_URL = 'https://geo.mozilla.org/country.js';
+    var GEO_URL = '{{ settings.GEO_URL }}';
     var GEO_CACHE_DURATION = 1000 * 60 * 60 * 24 * 30; // 30 days
 
     // showDefaultSnippets polyfill, available in about:home v4

--- a/snippets/base/templates/base/includes/snippet_js.html
+++ b/snippets/base/templates/base/includes/snippet_js.html
@@ -13,7 +13,7 @@
 var SNIPPET_METRICS_SAMPLE_RATE = {{ settings.METRICS_SAMPLE_RATE }};
 var SNIPPET_METRICS_URL = '{{ settings.METRICS_URL }}';
 var ABOUTHOME_SHOWN_SNIPPET = null;
-
+var USER_COUNTRY = null;
 
 // Start MozUITour
 // Copy from https://hg.mozilla.org/mozilla-central/file/tip/browser/components/uitour/UITour-lib.js
@@ -134,6 +134,7 @@ Mozilla.UITour.setConfiguration = function(configName, configValue) {
         gSnippetsMap = window.gSnippetsMap;
     }
 
+
     var show_snippet = null;
     if (ABOUTHOME_SNIPPETS.length > 0) {
         show_snippet = chooseSnippet(ABOUTHOME_SNIPPETS);
@@ -148,13 +149,6 @@ Mozilla.UITour.setConfiguration = function(configName, configValue) {
         document.getElementById('snippets').appendChild(snippetContainer);
         activateScriptTags(snippetContainer);
 
-        // Find the snippet div if it is present.
-        var snippetElement = null;
-        var elems = snippetContainer.getElementsByClassName('snippet');
-        if (elems.length > 0) {
-            snippetElement = elems[0];
-        }
-
         try {
             activateSnippetsButtonClick(show_snippet);
         } catch (err) {
@@ -162,41 +156,24 @@ Mozilla.UITour.setConfiguration = function(configName, configValue) {
             // activateSnippetsButtonClick
         }
 
-        // Determine snippet ID.
-        var metaParent = show_snippet.parentNode;
-        while (metaParent && metaParent.classList &&
-               !metaParent.classList.contains('snippet-metadata')) {
-            metaParent = metaParent.parentNode;
-        }
-
-
-        var show_snippet_id = 'unknown';
-        var show_snippet_campaign = '';
-        if (metaParent) {
-            show_snippet_id = metaParent.dataset.snippetId || 'unknown';
-            show_snippet_campaign = metaParent.dataset.campaign || '';
-        }
-        snippet_set.setAttribute('data-snippet-id', show_snippet_id);
-        snippet_set.setAttribute('data-campaign', show_snippet_campaign);
-        sendImpression();
-
-        // Trigger show_snippet event on snippet node.
-        var evt = document.createEvent('Event');
-        evt.initEvent('show_snippet', true, true);
-
-        // By the time show_snippet event reaches snippet_set the snippet
+        // By the time show_snippet event reaches #snippets the snippet
         // will have finished initializing and altering the DOM. It's the
         // time to modifyLinks() and addSnippetBlockLinks().
-        snippet_set.addEventListener('show_snippet', function(event) {
+        var snippets = document.getElementById('snippets');
+        snippets.addEventListener('show_snippet', function(event) {
             var topSection = document.getElementById('topSection');
             // Add sample rate and snippet ID to currently displayed links.
             var parameters = ('sample_rate=' + SNIPPET_METRICS_SAMPLE_RATE + '&snippet_name=' +
                               ABOUTHOME_SHOWN_SNIPPET.id);
             modifyLinks(topSection.querySelectorAll('a'), parameters);
             addSnippetBlockLinks(topSection.querySelectorAll('.block-snippet-button'));
+            sendImpression();
         });
-        show_snippet.dispatchEvent(evt);
 
+        // Trigger show_snippet event
+        var evt = document.createEvent('Event');
+        evt.initEvent('show_snippet', true, true);
+        snippetContainer.querySelector('.snippet').dispatchEvent(evt);
     } else {
         showDefaultSnippets();
     }
@@ -212,22 +189,20 @@ Mozilla.UITour.setConfiguration = function(configName, configValue) {
         downloadUserCountry();
     }
 
-    {# In preview mode, ignore geolocation. #}
     {% if preview %}
     function chooseSnippet(snippets) {
-        return snippets[Math.floor(Math.random() * snippets.length)];
+        return snippets[0];
     }
     {% else %}
     // Choose which snippet to display to the user based on various factors,
     // such as which country they are in.
     function chooseSnippet(snippets) {
-        var userCountry = getUserCountry();
-        if (userCountry) {
-            document.getElementById('snippet_set').dataset.userCountry = userCountry;
+        USER_COUNTRY = getUserCountry();
+        if (USER_COUNTRY) {
             snippets = snippets.filter(
                 function(snippet) {
-                    var countries = snippet.parentNode.dataset.countries;
-                    if (countries && countries.split(',').indexOf(userCountry) === -1) {
+                    var countries = snippet.countries;
+                    if (countries.length && countries.indexOf(USER_COUNTRY) === -1) {
                         return false;
                     }
                     return true;
@@ -235,13 +210,11 @@ Mozilla.UITour.setConfiguration = function(configName, configValue) {
             );
         }
         else {
-            document.getElementById('snippet_set').dataset.userCountry = '';
-
             // If we don't have the user's country, remove all geolocated snippets.
             // Bug 1140476
             snippets = snippets.filter(
                 function(snippet) {
-                    return !snippet.parentNode.dataset.countries;
+                    return snippet.countries.length === 0;
                 }
             )
         }
@@ -261,8 +234,8 @@ Mozilla.UITour.setConfiguration = function(configName, configValue) {
         if (searchProvider) {
             snippets = snippets.filter(
                 function(snippet) {
-                    var excludeFromSearchEngines = snippet.parentNode.getAttribute('data-exclude-from-search-engines');
-                    if (excludeFromSearchEngines && excludeFromSearchEngines.split(',').indexOf(searchProvider) !== -1) {
+                    var excludeFromSearchEngines = snippet.exclude_from_search_engines;
+                    if (excludeFromSearchEngines.length && excludeFromSearchEngines.indexOf(searchProvider) !== -1) {
                         return false;
                     }
                     return true;
@@ -274,8 +247,7 @@ Mozilla.UITour.setConfiguration = function(configName, configValue) {
         var blockList = getBlockList();
         snippets = snippets.filter(
             function (snippet) {
-                var snippet_id = parseInt(snippet.parentNode.getAttribute('data-snippet-id'), 10);
-                if (blockList.indexOf(snippet_id) === -1) {
+                if (blockList.indexOf(snippet.id) === -1) {
                     return true;
                 }
                 return false;
@@ -285,12 +257,13 @@ Mozilla.UITour.setConfiguration = function(configName, configValue) {
         // Choose a random snippet from the snippets list.
         if (snippets && snippets.length) {
             var sum = 0;
-            for (var k = 0; k < snippets.length; k++) {
+            var number_of_snippets = snippets.length;
+            for (var k = 0; k < number_of_snippets; k++) {
                 sum += snippets[k].weight;
                 snippets[k].weight = sum;
             }
             var random_number = Math.random() * sum;
-            for (var k = 0; k < snippets.length; k++) {
+            for (var k = 0; k < number_of_snippets; k++) {
                 if (random_number < snippets[k].weight) {
                     return snippets[k];
                 }
@@ -424,7 +397,7 @@ Mozilla.UITour.setConfiguration = function(configName, configValue) {
 
     // Add links to buttons that block snippets.
     function addSnippetBlockLinks(elements) {
-        var snippet_id = document.getElementById('snippet_set').getAttribute('data-snippet-id');
+        var snippet_id = ABOUTHOME_SHOWN_SNIPPET.id;
         var blockSnippet = function (event) {
             event.preventDefault();
             addToBlockList(snippet_id);
@@ -491,7 +464,7 @@ Mozilla.UITour.setConfiguration = function(configName, configValue) {
 
         // Handle about:accounts clicks.
         if (target.href && target.href.indexOf('about:accounts') === 0) {
-            var snippet_id = document.getElementById('snippet_set').getAttribute('data-snippet-id');
+            var snippet_id = ABOUTHOME_SHOWN_SNIPPET.id;
             var metric = snippet_id + '-about-accounts-click';
             var fire_event = function() {
                 var event = new CustomEvent(
@@ -512,35 +485,35 @@ Mozilla.UITour.setConfiguration = function(configName, configValue) {
 function sendMetric(metric, callback) {
     {# In preview mode, disable sampling, log metric, but do not send to service #}
     {% if preview %}
-    console.log("[preview mode] Sending metric: " + metric);
-    if (callback) {
-        callback();
-    }
-    return;
+      console.log("[preview mode] Sending metric: " + metric);
+      if (callback) {
+          callback();
+      }
+      return;
+    {% else %}
+      if ((Math.random() > SNIPPET_METRICS_SAMPLE_RATE) || (!metric)) {
+          if (callback) {
+              callback();
+          }
+          return;
+      }
+
+      var locale = '{{ locale }}';
+      var userCountry = USER_COUNTRY || '';
+      var campaign = ABOUTHOME_SHOWN_SNIPPET.campaign;
+      var snippet_id = ABOUTHOME_SHOWN_SNIPPET.id;
+
+      var url = (SNIPPET_METRICS_URL + '?snippet_name=' + snippet_id +
+                 '&locale=' + locale + '&country=' + userCountry +
+                 '&metric=' + metric + '&campaign=' + campaign);
+      var request = new XMLHttpRequest();
+      request.open('GET', url);
+      if (callback) {
+          request.addEventListener('loadend', callback, false);
+      }
+      request.send();
+      return request;
     {% endif %}
-
-    if ((Math.random() > SNIPPET_METRICS_SAMPLE_RATE) || (!metric)) {
-        if (callback) {
-            callback();
-        }
-        return;
-    }
-
-    var snippet_set = document.getElementById('snippet_set');
-    var locale = '{{ locale }}';
-    var userCountry = snippet_set.getAttribute('data-user-country') || '';
-    var campaign = snippet_set.getAttribute('data-campaign') || '';
-    var snippet_id = ABOUTHOME_SHOWN_SNIPPET.id;
-
-    var url = (SNIPPET_METRICS_URL + '?snippet_name=' + snippet_id +
-               '&locale=' + locale + '&country=' + userCountry + '&metric=' + metric + '&campaign=' + campaign);
-    var r = new XMLHttpRequest();
-    r.open('GET', url);
-    if (callback) {
-        r.addEventListener('loadend', callback, false);
-    }
-    r.send();
-    return r;
 }
 
 function popFromBlockList(snippetID) {

--- a/snippets/base/templates/base/includes/snippet_js.html
+++ b/snippets/base/templates/base/includes/snippet_js.html
@@ -8,9 +8,12 @@
   */
 (function(a,b,c){typeof c["module"]!="undefined"&&c.module.exports?c.module.exports=b():typeof c["define"]!="undefined"&&c["define"]=="function"&&c.define.amd?define(a,b):c[a]=b()})("$script",function(){function p(a,b){for(var c=0,d=a.length;c<d;++c)if(!b(a[c]))return j;return 1}function q(a,b){p(a,function(a){return!b(a)})}function r(a,b,i){function o(a){return a.call?a():d[a]}function t(){if(!--n){d[m]=1,l&&l();for(var a in f)p(a.split("|"),o)&&!q(f[a],o)&&(f[a]=[])}}a=a[k]?a:[a];var j=b&&b.call,l=j?b:i,m=j?a.join(""):b,n=a.length;return setTimeout(function(){q(a,function(a){if(h[a])return m&&(e[m]=1),h[a]==2&&t();h[a]=1,m&&(e[m]=1),s(!c.test(a)&&g?g+a+".js":a,t)})},0),r}function s(c,d){var e=a.createElement("script"),f=j;e.onload=e.onerror=e[o]=function(){if(e[m]&&!/^c|loade/.test(e[m])||f)return;e.onload=e[o]=null,f=1,h[c]=2,d()},e.async=1,e.src=c,b.insertBefore(e,b.firstChild)}var a=document,b=a.getElementsByTagName("head")[0],c=/^https?:\/\//,d={},e={},f={},g,h={},i="string",j=!1,k="push",l="DOMContentLoaded",m="readyState",n="addEventListener",o="onreadystatechange";return!a[m]&&a[n]&&(a[n](l,function t(){a.removeEventListener(l,t,j),a[m]="complete"},j),a[m]="loading"),r.get=s,r.order=function(a,b,c){(function d(e){e=a.shift(),a.length?r(e,d):r(e,b,c)})()},r.path=function(a){g=a},r.ready=function(a,b,c){a=a[k]?a:[a];var e=[];return!q(a,function(a){d[a]||e[k](a)})&&p(a,function(a){return d[a]})?b():!function(a){f[a]=f[a]||[],f[a][k](b),c&&c(e)}(a.join("|")),r},r},this);
 
+
 'use strict';
 var SNIPPET_METRICS_SAMPLE_RATE = 0.1;
 var SNIPPET_METRICS_URL = 'https://snippets-stats.mozilla.org/foo.html';
+var ABOUTHOME_SHOWN_SNIPPET = null;
+
 
 // Start MozUITour
 // Copy from https://hg.mozilla.org/mozilla-central/file/tip/browser/components/uitour/UITour-lib.js
@@ -98,8 +101,6 @@ Mozilla.UITour.setConfiguration = function(configName, configValue) {
 };
 // End MozUITour
 
-
-
 (function(showDefaultSnippets) {
     'use strict';
 
@@ -132,16 +133,26 @@ Mozilla.UITour.setConfiguration = function(configName, configValue) {
         gSnippetsMap = window.gSnippetsMap;
     }
 
-    var snippets = (document.getElementById('snippetContainer')
-                    .querySelectorAll('.snippet'));
     var show_snippet = null;
-    if (snippets.length > 0) {
-        show_snippet = chooseSnippet(snippets);
+    if (ABOUTHOME_SNIPPETS.length > 0) {
+        show_snippet = chooseSnippet(ABOUTHOME_SNIPPETS);
     }
 
     if (show_snippet) {
-        var snippet_set = document.getElementById('snippet_set');
-        show_snippet.style.display = 'block';
+        ABOUTHOME_SHOWN_SNIPPET = show_snippet;
+
+        // Inject the snippet onto the page.
+        var snippetContainer = document.createElement('div');
+        snippetContainer.innerHTML = show_snippet.code;
+        document.getElementById('snippets').appendChild(snippetContainer);
+        activateScriptTags(snippetContainer);
+
+        // Find the snippet div if it is present.
+        var snippetElement = null;
+        var elems = snippetContainer.getElementsByClassName('snippet');
+        if (elems.length > 0) {
+            snippetElement = elems[0];
+        }
 
         try {
             activateSnippetsButtonClick(show_snippet);
@@ -156,6 +167,7 @@ Mozilla.UITour.setConfiguration = function(configName, configValue) {
                !metaParent.classList.contains('snippet-metadata')) {
             metaParent = metaParent.parentNode;
         }
+
 
         var show_snippet_id = 'unknown';
         var show_snippet_campaign = '';
@@ -183,6 +195,7 @@ Mozilla.UITour.setConfiguration = function(configName, configValue) {
             addSnippetBlockLinks(topSection.querySelectorAll('.block-snippet-button'));
         });
         show_snippet.dispatchEvent(evt);
+
     } else {
         showDefaultSnippets();
     }
@@ -207,9 +220,6 @@ Mozilla.UITour.setConfiguration = function(configName, configValue) {
     // Choose which snippet to display to the user based on various factors,
     // such as which country they are in.
     function chooseSnippet(snippets) {
-        // Convert HTMLCollection to Array.
-        snippets = [].slice.call(snippets);
-
         var userCountry = getUserCountry();
         if (userCountry) {
             document.getElementById('snippet_set').dataset.userCountry = userCountry;
@@ -275,12 +285,12 @@ Mozilla.UITour.setConfiguration = function(configName, configValue) {
         if (snippets && snippets.length) {
             var sum = 0;
             for (var k = 0; k < snippets.length; k++) {
-                sum += parseInt(snippets[k].parentNode.dataset.weight, 10) || 100;
-                snippets[k].parentNode.dataset.weight = sum;
+                sum += snippets[k].weight;
+                snippets[k].weight = sum;
             }
             var random_number = Math.random() * sum;
             for (var k = 0; k < snippets.length; k++) {
-                if (random_number < snippets[k].parentNode.dataset.weight) {
+                if (random_number < snippets[k].weight) {
                     return snippets[k];
                 }
             }
@@ -292,13 +302,7 @@ Mozilla.UITour.setConfiguration = function(configName, configValue) {
 
     // Check whether snippet links to about:accounts.
     function hasAboutAccountsLink(snippet) {
-        var links = snippet.getElementsByTagName('a')
-        for (var i = 0; i < links.length; i++) {
-            if (links[i].href.indexOf('about:accounts') === 0) {
-                return true;
-            }
-        }
-        return false;
+        return snippet.code.indexOf('href="about:accounts"') !== -1;
     }
 
     function isFxAccountSetup() {
@@ -444,6 +448,18 @@ Mozilla.UITour.setConfiguration = function(configName, configValue) {
         }
     }
 
+    // Scripts injected by innerHTML are inactive, so we have to relocate them
+    // through DOM manipulation to activate their contents.
+    // (Adapted from http://mxr.mozilla.org/mozilla-central/source/browser/base/content/abouthome/aboutHome.js)
+    function activateScriptTags(element) {
+       Array.forEach(element.getElementsByTagName('script'), function(elt) {
+           var relocatedScript = document.createElement('script');
+           relocatedScript.type = 'text/javascript;version=1.8';
+           relocatedScript.text = elt.text;
+           elt.parentNode.replaceChild(relocatedScript, elt);
+       });
+    }
+
     // Listen for clicks on links, send metrics and handle
     // about:account custom links.
     var topSection = document.getElementById('topSection');
@@ -510,10 +526,11 @@ function sendMetric(metric, callback) {
     }
 
     var snippet_set = document.getElementById('snippet_set');
-    var locale = snippet_set.getAttribute('data-locale');
+    var locale = '{{ locale }}';
     var userCountry = snippet_set.getAttribute('data-user-country') || '';
     var campaign = snippet_set.getAttribute('data-campaign') || '';
-    var snippet_id = snippet_set.getAttribute('data-snippet-id');
+    var snippet_id = ABOUTHOME_SHOWN_SNIPPET.id;
+
     var url = (SNIPPET_METRICS_URL + '?snippet_name=' + snippet_id +
                '&locale=' + locale + '&country=' + userCountry + '&metric=' + metric + '&campaign=' + campaign);
     var r = new XMLHttpRequest();

--- a/snippets/base/templates/base/preview.html
+++ b/snippets/base/templates/base/preview.html
@@ -28,11 +28,7 @@
       <div id="snippetContainer">
         <div id="snippets">
           {% block snippets %}
-            <div class="snippet_set" id="snippet_set">
-              {% include 'base/includes/snippet_css.html' %}
-              {{ snippet.render() }}
-              {% include 'base/includes/snippet_js.html' %}
-            </div>
+            {% include 'base/fetch_snippets.html' %}
           {% endblock %}
         </div>
       </div>

--- a/snippets/base/tests/test_views.py
+++ b/snippets/base/tests/test_views.py
@@ -56,7 +56,14 @@ class FetchRenderSnippetsTests(TestCase):
         params = self.client_params
         response = self.client.get('/{0}/'.format('/'.join(params)))
 
-        eq_(set(snippets_ok), set(response.context['snippets']))
+        snippets_json = json.dumps([{
+            'id': snippet.id,
+            'code': snippet.render(),
+            'country': snippet.country,
+            'weight': snippet.weight,
+        } for snippet in snippets_ok])
+
+        eq_(set(snippets_json), set(response.context['snippets_json']))
         eq_(response.context['locale'], 'en-US')
 
     @patch('snippets.base.views.Client', wraps=Client)

--- a/snippets/base/tests/test_views.py
+++ b/snippets/base/tests/test_views.py
@@ -52,18 +52,11 @@ class FetchRenderSnippetsTests(TestCase):
         # Snippet that doesn't match.
         SnippetFactory.create(on_nightly=False),
 
-        snippets_ok = [snippet_1]
         params = self.client_params
         response = self.client.get('/{0}/'.format('/'.join(params)))
 
-        snippets_json = json.dumps([{
-            'id': snippet.id,
-            'code': snippet.render(),
-            'country': snippet.country,
-            'weight': snippet.weight,
-        } for snippet in snippets_ok])
-
-        eq_(set(snippets_json), set(response.context['snippets_json']))
+        snippets_json = json.dumps([snippet_1.to_dict()])
+        eq_(snippets_json, response.context['snippets_json'])
         eq_(response.context['locale'], 'en-US')
 
     @patch('snippets.base.views.Client', wraps=Client)
@@ -206,9 +199,8 @@ class PreviewSnippetTests(TestCase):
         response = self._preview_snippet(template_id=template.id, data=data)
         eq_(response.status_code, 200)
 
-        snippet = response.context['snippet']
-        eq_(snippet.template, template)
-        eq_(snippet.data, data)
+        snippet = response.context['snippets_json']
+        ok_(json.loads(snippet))
 
 
 class ShowSnippetTests(TestCase):

--- a/snippets/base/views.py
+++ b/snippets/base/views.py
@@ -116,15 +116,9 @@ def fetch_render_snippets(request, **kwargs):
                          .order_by('priority')
                          .select_related('template')
                          .filter_by_available())
-    matching_snippets_json = json.dumps([{
-        'id': snippet.id,
-        'code': snippet.render(),
-        'country': snippet.country,
-        'weight': snippet.weight,
-    } for snippet in matching_snippets])
 
     response = render(request, 'base/fetch_snippets.html', {
-        'snippets_json': matching_snippets_json,
+        'snippets_json': json.dumps([s.to_dict() for s in matching_snippets]),
         'client': client,
         'locale': client.locale,
     })
@@ -196,9 +190,9 @@ def preview_snippet(request):
     template_name = 'base/preview_without_shell.html' if skip_boilerplate else 'base/preview.html'
 
     return render(request, template_name, {
-        'snippet': snippet,
+        'snippets_json': json.dumps([snippet.to_dict()]),
         'client': PREVIEW_CLIENT,
-        'preview': True
+        'preview': True,
     })
 
 
@@ -208,9 +202,9 @@ def show_snippet(request, snippet_id):
         raise Http404()
 
     return render(request, 'base/preview.html', {
-        'snippet': snippet,
+        'snippets_json': json.dumps([snippet.to_dict()]),
         'client': PREVIEW_CLIENT,
-        'preview': True
+        'preview': True,
     })
 
 

--- a/snippets/base/views.py
+++ b/snippets/base/views.py
@@ -116,9 +116,15 @@ def fetch_render_snippets(request, **kwargs):
                          .order_by('priority')
                          .select_related('template')
                          .filter_by_available())
+    matching_snippets_json = json.dumps([{
+        'id': snippet.id,
+        'code': snippet.render(),
+        'country': snippet.country,
+        'weight': snippet.weight,
+    } for snippet in matching_snippets])
 
     response = render(request, 'base/fetch_snippets.html', {
-        'snippets': matching_snippets,
+        'snippets_json': matching_snippets_json,
         'client': client,
         'locale': client.locale,
     })

--- a/snippets/settings/base.py
+++ b/snippets/settings/base.py
@@ -95,3 +95,8 @@ SOUTH_MIGRATION_MODULES = {
 }
 
 SNIPPET_BUNDLE_TIMEOUT = 15 * 60  # 15 minutes
+
+METRICS_URL = 'https://snippets-stats.mozilla.org/foo.html'
+METRICS_SAMPLE_RATE = 0.1
+
+GEO_URL = 'https://geo.mozilla.org/country.js'


### PR DESCRIPTION
Change the way snippets are packaged. Currently the snippets are injected directly into the document as DOM elements and therefore a snippets can alter other snippets' behavior or appearance. We fight this by using `{{ snippet_id }}` identifiers everywhere but this is error prone. 

This pull request packages the snippets as JSON and the javascript on the client selects one snippet per time and injects only this one into the document.

@pmclanahan r? for backend and @alexgibson or @schalkneethling for frontend r?

Replaces #82 

Verify that works
 - [x] With many Firefox versions tested from Firefox 15 to Firefox 42
 - [x] Send metric with correct id, campaign, metric, locale, country
 - [x] Send custom metric
 - [x] Snippet's JS gets executed
 - [x] Snippet Preview
 - [x] Snippet weights calculated correctly
 - [x] Check snippet bundles
 