### PR TITLE
Make polyfil global.

### DIFF
--- a/snippets/base/templates/base/includes/snippet_js.html
+++ b/snippets/base/templates/base/includes/snippet_js.html
@@ -126,6 +126,7 @@ Mozilla.UITour.setConfiguration = function(configName, configValue) {
                 return localStorage[key];
             }
         };
+        window.gSnippetsMap = gSnippetsMap;
     } else {
         // localStorage isn't available, use gSnippetsMap (backed by IndexedDB).
         gSnippetsMap = window.gSnippetsMap;


### PR DESCRIPTION
Firefox versions up to and including version 21 use this polyfil for
gSnippetsMap. Block list functions which leave outside the scope need
access to the polyfil.