### PR TITLE
Change Array.unshift to concat.

### DIFF
--- a/snippets/base/templates/base/includes/snippet_js.html
+++ b/snippets/base/templates/base/includes/snippet_js.html
@@ -530,7 +530,7 @@ function addToBlockList(snippetID) {
     var blockList = getBlockList();
     snippetID = parseInt(snippetID, 10);
     if (blockList.indexOf(snippetID) === -1) {
-        blockList.unshift(snippetID);
+        blockList = [snippetID].concat(blockList);
         gSnippetsMap.set('blockList', blockList);
     }
 }


### PR DESCRIPTION
Array.unshift is not supported in Fx <22. Use concat lists to mimic the
behavior.