### PR TITLE
Add snippet ids in response.

### DIFF
--- a/snippets/base/models.py
+++ b/snippets/base/models.py
@@ -175,6 +175,7 @@ class SnippetBundle(object):
     def generate(self):
         """Generate and save the code for this snippet bundle."""
         bundle_content = render_to_string('base/fetch_snippets.html', {
+            'snippet_ids': [snippet.id for snippet in self.snippets],
             'snippets_json': json.dumps([s.to_dict() for s in self.snippets]),
             'client': self.client,
             'locale': self.client.locale,

--- a/snippets/base/templates/base/fetch_snippets.html
+++ b/snippets/base/templates/base/fetch_snippets.html
@@ -1,4 +1,10 @@
 {% include 'base/includes/snippet_css.html' %}
+<!--
+Included snippets:
+{% for id in snippet_ids %}
+  - {{ id }}
+{% endfor %}
+-->
 <script type="text/javascript">
   var ABOUTHOME_SNIPPETS = JSON.parse('{{ snippets_json|escapejs|safe }}');
 </script>

--- a/snippets/base/tests/test_models.py
+++ b/snippets/base/tests/test_models.py
@@ -433,6 +433,7 @@ class SnippetBundleTests(TestCase):
                     bundle.generate()
 
         render_to_string.assert_called_with('base/fetch_snippets.html', {
+            'snippet_ids': [s.id for s in [self.snippet1, self.snippet2]],
             'snippets_json': json.dumps([s.to_dict() for s in [self.snippet1, self.snippet2]]),
             'client': bundle.client,
             'locale': 'fr',

--- a/snippets/base/views.py
+++ b/snippets/base/views.py
@@ -118,6 +118,7 @@ def fetch_render_snippets(request, **kwargs):
                          .filter_by_available())
 
     response = render(request, 'base/fetch_snippets.html', {
+        'snippet_ids': [snippet.id for snippet in matching_snippets],
         'snippets_json': json.dumps([s.to_dict() for s in matching_snippets]),
         'client': client,
         'locale': client.locale,


### PR DESCRIPTION
Since we're now sending snippets in a json encoded format it's harder to
identifiy which snippets are included. This commit add an html comment
with the ids of the snippets included in each response.