### PR TITLE
 [bug 1233001] Switch non release channels to MLS 

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,3 +23,4 @@ Contents
    developing
    contributing
    data_collection
+   geolocation

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -94,8 +94,9 @@ Once the code is injected, the included JavaScript:
 
 - Identifies all elements in the snippet code with the ``snippet`` class as
   potential snippets to display.
-- Filters out snippets that don't match the user's location (determined via IP
-  and stored locally to preserve privacy).
+- Filters out snippets that don't match the user's location. See
+  :doc:`geolocation` for information on how we retrieve and store
+  geolocation data.
 - Filters out snippets that are only supposed to be shown to users without a
   Firefox account.
 - Filters out snippets that are only supposed to be shown to users with a
@@ -107,9 +108,10 @@ Once the code is injected, the included JavaScript:
 - Triggers a ``show_snippet`` event on the ``.snippet`` element.
 - Modifies all ``<a>`` tags in the snippet to add the snippet ID as a
   URL parameter.
-- Logs an impression for the displayed snippet by sending a request to the
-  snippets metrics server. These requests are sampled and only go out 10% of
-  the time.
+- Logs an impression for the displayed snippet by sending a request to
+  the snippets metrics server. These requests are sampled and only go
+  out 10% of the time. See also :doc:`data_collection` chapter for more
+  information on the data send to the metrics server.
 
 If no snippets are available, the code falls back to showing default snippets
 included within Firefox itself.

--- a/snippets/base/templates/base/includes/snippet_js.html
+++ b/snippets/base/templates/base/includes/snippet_js.html
@@ -1,5 +1,6 @@
 <script type="text/javascript">
 //<![CDATA[
+{% if client.channel == 'release' %}
 /*!
   * $script.js Async loader & dependency manager
   * https://github.com/ded/script.js
@@ -7,13 +8,16 @@
   * License: MIT
   */
 (function(a,b,c){typeof c["module"]!="undefined"&&c.module.exports?c.module.exports=b():typeof c["define"]!="undefined"&&c["define"]=="function"&&c.define.amd?define(a,b):c[a]=b()})("$script",function(){function p(a,b){for(var c=0,d=a.length;c<d;++c)if(!b(a[c]))return j;return 1}function q(a,b){p(a,function(a){return!b(a)})}function r(a,b,i){function o(a){return a.call?a():d[a]}function t(){if(!--n){d[m]=1,l&&l();for(var a in f)p(a.split("|"),o)&&!q(f[a],o)&&(f[a]=[])}}a=a[k]?a:[a];var j=b&&b.call,l=j?b:i,m=j?a.join(""):b,n=a.length;return setTimeout(function(){q(a,function(a){if(h[a])return m&&(e[m]=1),h[a]==2&&t();h[a]=1,m&&(e[m]=1),s(!c.test(a)&&g?g+a+".js":a,t)})},0),r}function s(c,d){var e=a.createElement("script"),f=j;e.onload=e.onerror=e[o]=function(){if(e[m]&&!/^c|loade/.test(e[m])||f)return;e.onload=e[o]=null,f=1,h[c]=2,d()},e.async=1,e.src=c,b.insertBefore(e,b.firstChild)}var a=document,b=a.getElementsByTagName("head")[0],c=/^https?:\/\//,d={},e={},f={},g,h={},i="string",j=!1,k="push",l="DOMContentLoaded",m="readyState",n="addEventListener",o="onreadystatechange";return!a[m]&&a[n]&&(a[n](l,function t(){a.removeEventListener(l,t,j),a[m]="complete"},j),a[m]="loading"),r.get=s,r.order=function(a,b,c){(function d(e){e=a.shift(),a.length?r(e,d):r(e,b,c)})()},r.path=function(a){g=a},r.ready=function(a,b,c){a=a[k]?a:[a];var e=[];return!q(a,function(a){d[a]||e[k](a)})&&p(a,function(a){return d[a]})?b():!function(a){f[a]=f[a]||[],f[a][k](b),c&&c(e)}(a.join("|")),r},r},this);
+{% endif %}
 
 
 'use strict';
+
 var SNIPPET_METRICS_SAMPLE_RATE = {{ settings.METRICS_SAMPLE_RATE }};
 var SNIPPET_METRICS_URL = '{{ settings.METRICS_URL }}';
 var ABOUTHOME_SHOWN_SNIPPET = null;
 var USER_COUNTRY = null;
+var GEO_CACHE_DURATION = 1000 * 60 * 60 * 24 * 30; // 30 days
 
 // Start MozUITour
 // Copy from https://hg.mozilla.org/mozilla-central/file/tip/browser/components/uitour/UITour-lib.js
@@ -104,9 +108,6 @@ Mozilla.UITour.setConfiguration = function(configName, configValue) {
 
 (function(showDefaultSnippets) {
     'use strict';
-
-    var GEO_URL = '{{ settings.GEO_URL }}';
-    var GEO_CACHE_DURATION = 1000 * 60 * 60 * 24 * 30; // 30 days
 
     // showDefaultSnippets polyfill, available in about:home v4
     if (typeof showDefaultSnippets !== 'function') {
@@ -355,19 +356,46 @@ Mozilla.UITour.setConfiguration = function(configName, configValue) {
         }
     }
 
-    // Download the user's country using the geolocation service.
-    function downloadUserCountry() {
-        $script(GEO_URL, 'geo');
-        $script.ready('geo', function() {
-            try {
-                gSnippetsMap.set('geoCountry', geoip_country_code());
-                gSnippetsMap.set('geoLastUpdated', new Date());
-            } catch (e) {
-                // Most likely failed to load JS file. Continue on without us,
-                // we'll try again next time.
-            }
-        });
-    }
+    {% if client.channel == 'release' %}
+      function downloadUserCountry() {
+          var GEO_URL = "{{ settings.OLD_GEO_URL }}";
+          $script(GEO_URL, 'geo');
+          $script.ready('geo', function() {
+              try {
+                  gSnippetsMap.set('geoCountry', geoip_country_code());
+                  gSnippetsMap.set('geoLastUpdated', new Date());
+              } catch (e) {
+                  // Most likely failed to load JS file. Continue on without us,
+                  // we'll try again next time.
+              }
+          });
+      }
+    {% else %}
+      // Download the user's country using the geolocation service.
+      // Please do not directly use this code or Snippets key.
+      // Contact MLS team for your own credentials.
+      // https://location.services.mozilla.com/contact
+      function downloadUserCountry() {
+          var GEO_URL = "{{ settings.GEO_URL }}";
+          var request = new XMLHttpRequest();
+          request.timeout = 60000;
+          request.onreadystatechange = function() {
+              if (request.readyState == 4 && request.status == 200) {
+                  var country_data = JSON.parse(request.responseText);
+
+                  try {
+                      gSnippetsMap.set('geoCountry', country_data.country_code);
+                      gSnippetsMap.set('geoLastUpdated', new Date());
+                  } catch (e) {
+                      // Most likely failed to load Data file. Continue on without us,
+                      // we'll try again next time.
+                  }
+              }
+          };
+          request.open('GET', GEO_URL, true);
+          request.send();
+      }
+    {% endif %}
 
     // Notifies stats server that the given snippet ID
     // was shown. No personally-identifiable information

--- a/snippets/settings/base.py
+++ b/snippets/settings/base.py
@@ -99,4 +99,5 @@ SNIPPET_BUNDLE_TIMEOUT = 15 * 60  # 15 minutes
 METRICS_URL = 'https://snippets-stats.mozilla.org/foo.html'
 METRICS_SAMPLE_RATE = 0.1
 
-GEO_URL = 'https://geo.mozilla.org/country.js'
+OLD_GEO_URL = 'https://geo.mozilla.org/country.js'
+GEO_URL = 'https://location.services.mozilla.com/v1/country?key=fff72d56-b040-4205-9a11-82feda9d83a3'


### PR DESCRIPTION
GeoDude (geo.mozilla.org) will be decommissioned soon and the snippets service needs to switch to MLS for location info.

