### PR TITLE
Ignore 404 in FetchSnippetsMiddleware.

### DIFF
--- a/snippets/base/middleware.py
+++ b/snippets/base/middleware.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import resolve
+from django.core.urlresolvers import Resolver404, resolve
 
 from snippets.base.views import fetch_json_snippets, fetch_snippets
 
@@ -15,6 +15,10 @@ class FetchSnippetsMiddleware(object):
     and executes the view early, bypassing the rest of the middleware.
     """
     def process_request(self, request):
-        result = resolve(request.path)
+        try:
+            result = resolve(request.path)
+        except Resolver404:
+            return
+
         if result.func in (fetch_snippets, fetch_json_snippets):
             return result.func(request, *result.args, **result.kwargs)

--- a/snippets/base/tests/test_middleware.py
+++ b/snippets/base/tests/test_middleware.py
@@ -1,5 +1,7 @@
 from mock import Mock, patch
 
+from django.test import RequestFactory
+
 from snippets.base.middleware import FetchSnippetsMiddleware
 from snippets.base.tests import TestCase
 
@@ -53,4 +55,8 @@ class FetchSnippetsMiddlewareTests(TestCase):
         result = resolve.return_value
         result.func = lambda request: 'asdf'
 
+        self.assertEqual(self.middleware.process_request(request), None)
+
+    def test_unknown_url(self):
+        request = RequestFactory().get('/admin')
         self.assertEqual(self.middleware.process_request(request), None)


### PR DESCRIPTION
FetchSnippetsMiddleware tries to resolve request.path which can raise a
404 if the path doesn't exist. The exception should be ignored to allow
the rest of the middlewares to run and handle the 404. This will allo
Django to append slash to URLs and fix the /admin VS /admin/ problem.