### PR TITLE
Add option to disable admin

### DIFF
--- a/snippets/settings.py
+++ b/snippets/settings.py
@@ -168,6 +168,8 @@ SOUTH_MIGRATION_MODULES = {
     'waffle': 'waffle.south_migrations',
 }
 
+ENABLE_ADMIN = config('ENABLE_ADMIN', default=True, cast=bool)
+
 ANON_ALWAYS = True
 
 SNIPPET_BUNDLE_TIMEOUT = 15 * 60  # 15 minutes

--- a/snippets/urls.py
+++ b/snippets/urls.py
@@ -13,13 +13,16 @@ def robots_txt(request):
 
 urlpatterns = [
     url(r'', include('snippets.base.urls')),
-    url(r'^admin/', include('smuggler.urls')),
-    url(r'^admin/', include(admin.site.urls)),
     url(r'^robots\.txt$', robots_txt)
 ]
 
-admin.site.site_header = 'Snippets Administration'
-admin.site.site_title = 'Mozilla Snippets'
+if settings.ENABLE_ADMIN:
+    urlpatterns += [
+        url(r'^admin/', include('smuggler.urls')),
+        url(r'^admin/', include(admin.site.urls)),
+    ]
+    admin.site.site_header = 'Snippets Administration'
+    admin.site.site_title = 'Mozilla Snippets'
 
 # In DEBUG mode, serve media files through Django.
 if settings.DEBUG:

--- a/snippets/urls.py
+++ b/snippets/urls.py
@@ -18,6 +18,9 @@ urlpatterns = [
     url(r'^robots\.txt$', robots_txt)
 ]
 
+admin.site.site_header = 'Snippets Administration'
+admin.site.site_title = 'Mozilla Snippets'
+
 # In DEBUG mode, serve media files through Django.
 if settings.DEBUG:
     # Use custom serve function that adds necessary headers.


### PR DESCRIPTION
This option will be needed in the instances pointing to the read-only db
replica to prevent users from logging in and trying to make changes.

Also fix the admin title 'cause why not?