### PR TITLE
Remove django-sha2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -84,9 +84,6 @@ django-mozilla-product-details==0.10
 # sha256: sqKdMSc4F3L6h2nBx_rcW3C2NTOByJ4Bg6M-KadFIbo
 https://github.com/alex/django-filter/archive/70063a947f3a5cb434abe0e5623d02ec4f3bd75a.tar.gz#egg=django_filter
 
-# sha256: B01srfwR4nxRsIj3mXDeD7biBI_2tN6fys7hIABEn1g
-https://github.com/fwenzel/django-sha2/archive/f4519bf0cc9b1dd7a7d78394fa4aec4504bc86e9.tar.gz#egg=django_sha2
-
 # sha256: nNnjqXaEmjzYFoMNeBG5NUPB3J2p88sczC-dqDG4sCU
 # sha256: kUtLh0-mJQoIl7wwtn4CA02SpyNatyqRv22km3F1HeQ
 django-waffle==0.11

--- a/snippets/settings.py
+++ b/snippets/settings.py
@@ -12,7 +12,6 @@ import os
 import dj_database_url
 import django_cache_url
 from decouple import Csv, config
-from django_sha2 import get_password_hashers
 
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -145,26 +144,6 @@ TEMPLATES = [
         }
     },
 ]
-
-PASSWORD_HASHERS = [
-    'django.contrib.auth.hashers.PBKDF2PasswordHasher',
-    'django.contrib.auth.hashers.PBKDF2SHA1PasswordHasher',
-    'django.contrib.auth.hashers.BCryptSHA256PasswordHasher',
-    'django.contrib.auth.hashers.BCryptPasswordHasher',
-    'django.contrib.auth.hashers.SHA1PasswordHasher',
-    'django.contrib.auth.hashers.MD5PasswordHasher',
-    'django.contrib.auth.hashers.CryptPasswordHasher',
-    'django_sha2.hashers.BcryptHMACCombinedPasswordVerifier',
-    'django_sha2.hashers.SHA512PasswordHasher',
-    'django_sha2.hashers.SHA256PasswordHasher',
-]
-
-# TODO
-HMAC_KEYS = {
-    '2012-06-06': 'some secret',
-}
-
-PASSWORD_HASHERS = get_password_hashers(PASSWORD_HASHERS, HMAC_KEYS)
 
 SNIPPET_SIZE_LIMIT = 500
 SNIPPET_IMAGE_SIZE_LIMIT = 250


### PR DESCRIPTION
On Deis we'll implement Okta and have no passwords. Remove django-sha2
dependency as deprecated.