### PR TITLE
Make BUNDLES and FILES root configurable.

### DIFF
--- a/snippets/base/tests/test_models.py
+++ b/snippets/base/tests/test_models.py
@@ -336,11 +336,11 @@ class UploadedFileTests(TestCase):
             settings_mock.SITE_URL = 'http://example.com/foo/'
             self.assertEqual(test_file.url, 'http://example.com/foo/bar')
 
+    @override_settings(MEDIA_FILES_ROOT='filesroot/')
     @patch('snippets.base.models.uuid')
     def test_generate_new_filename(self, uuid_mock):
         uuid_mock.uuid4.return_value = 'bar'
         file = UploadedFileFactory.build()
-        UploadedFile.FILES_ROOT = 'filesroot'
         filename = _generate_filename(file, 'filename.boing')
         self.assertEqual(filename, 'filesroot/bar.boing')
 

--- a/snippets/settings.py
+++ b/snippets/settings.py
@@ -104,8 +104,10 @@ STATIC_URL = config('STATIC_URL', '/static/')
 if not DEBUG_TEMPLATE:
     STATICFILES_STORAGE = 'whitenoise.django.GzipManifestStaticFilesStorage'
 
-MEDIA_ROOT = config('MEDIA_ROOT', default=os.path.join(BASE_DIR, 'media'))
 MEDIA_URL = config('MEDIA_URL', '/media/')
+MEDIA_ROOT = config('MEDIA_ROOT', default=os.path.join(BASE_DIR, 'media'))
+MEDIA_FILES_ROOT = config('MEDIA_FILES_ROOT', default='files/')
+MEDIA_BUNDLES_ROOT = config('MEDIA_BUNDLES_ROOT', default='bundles/')
 
 SESSION_COOKIE_SECURE = config('SESSION_COOKIE_SECURE', default=not DEBUG, cast=bool)
 
@@ -183,6 +185,10 @@ if SAML_ENABLE:
 
 
 DEFAULT_FILE_STORAGE = config('FILE_STORAGE', 'storages.backends.overwrite.OverwriteStorage')
+
+CDN_URL = config('CDN_URL', default='')
+
+
 # Set to 'storages.backends.s3boto.S3BotoStorage' for S3
 if DEFAULT_FILE_STORAGE == 'snippets.base.storage.S3Storage':
     AWS_ACCESS_KEY_ID = config('AWS_ACCESS_KEY_ID')


### PR DESCRIPTION
We can set `us-west` instances to save to `bundles/*` directory in their own `us-west` S3 bucket and the `eu-west` instances to save to `eu-west/bundles/*` directory in the own `eu-west` S3 buckets.

Then we can have one CloudFront CDN with two origins, the `eu-west` and the `us-west` S3 buckets and create a `Behavior` to fetch all `eu-west/*` matching files from `eu-west` and the rest from `us-west`. 

How does that sound @jgmize?