### PR TITLE
stopPropagation while block snippet button gets clicked.

### DIFF
--- a/snippets/base/templates/base/includes/snippet.js
+++ b/snippets/base/templates/base/includes/snippet.js
@@ -402,6 +402,8 @@ Mozilla.UITour.setConfiguration = function(configName, configValue) {
         var snippet_id = ABOUTHOME_SHOWN_SNIPPET.id;
         var blockSnippet = function (event) {
             event.preventDefault();
+            event.stopPropagation();
+
             addToBlockList(snippet_id);
 
             // Waiting for 500ms before reloading the page after user blocks a snippet,


### PR DESCRIPTION
In some snippet templates which can become globally clickable (i.e.
snippet as a button) the block button in included in a global <a>
element. In some cases and FF versoisn when clicking the block button
the event propages all the way to the <a> and gets the user in another
page. stopPropagation fixes this.