### PR TITLE
On the fly compile nunjucks templates.

### DIFF
--- a/snippets/base/forms.py
+++ b/snippets/base/forms.py
@@ -85,12 +85,11 @@ class TemplateDataWidget(forms.TextInput):
         css = {
             'all': ('css/templateDataWidget.css',)
         }
-        js = filter(None, [
+        js = [
             'js/lib/jquery-2.2.1.min.js',
             'js/lib/nunjucks{0}.js'.format('-dev' if settings.DEBUG else ''),
-            'templates/compiled.js' if not settings.DEBUG else None,
             'js/templateDataWidget.js'
-        ])
+        ]
 
 
 class IconWidget(forms.TextInput):


### PR DESCRIPTION
In the current SLC3 setup we [precompile nunjucks templates](https://github.com/mozilla/snippets-service/blob/legacy/bin/update/deploy.py#L53-L57) but to avoid installing node, npm and nunjucks in docker images, we will load and compile the tiny admin only nunjucks templates in the browser.

The two tiny nunjucks templates are used only in /admin
https://github.com/mozilla/snippets-service/tree/master/snippets/base/static/templates
