### PR TITLE
Use cron instead of interval for clock jobs.

### DIFF
--- a/scripts/cron.py
+++ b/scripts/cron.py
@@ -56,7 +56,7 @@ def ping_dms(function):
     return _ping
 
 
-@scheduled_job('interval', days=1, max_instances=1, coalesce=True)
+@scheduled_job('cron', month='*', day='*', hour='1', minute='10', max_instances=1, coalesce=True)
 @ping_dms
 def job_update_product_details():
     call_command('update_product_details')


### PR DESCRIPTION
The update_product_details job runs every day and on every restart of
the clock process (e.g. when we push new code) the count starts from the
beginning.

For example if 23 hours have passed since the last trigger and the job
is to go off in an hour, if we push code the job store will be cleared
out the job_update_product_details job will be re-scheduled to trigger
in 24 hours. In this case the job will run in 23+24=47 hours if we don't
push code meanwhile which will result in even later rescheduling of the
job.

This change uses cron like scheduling based on the system clock. The job
will be triggered daily at 01:10 independently of the restarts of the
job.

Since we're not using a permanent store of the jobs, if the clock
process is not running at the scheduled time there will be a miss, but
that's rather unlikely and Dead Man's Snitch will keep us up to date.