### PR TITLE
Fix import typo in scripts.cron

### DIFF
--- a/scripts/cron.py
+++ b/scripts/cron.py
@@ -9,7 +9,7 @@ from django.conf import settings
 import requests
 from apscheduler.schedulers.blocking import BlockingScheduler
 
-from snippets.base.utils import create_countries, create_locales
+from snippets.base.util import create_countries, create_locales
 
 
 schedule = BlockingScheduler()


### PR DESCRIPTION
Fix typo introduced in https://github.com/mozilla/snippets-service/pull/184/files#diff-9d35a2d87ae415b7e8126e0570e0229eR12 and job has been broken since that was deployed due to `ImportError: No module named utils`.