### PR TITLE
Add ENV LANG=C.UTF-8 to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,3 +25,4 @@ COPY . /app
 RUN DEBUG=False SECRET_KEY=foo ALLOWED_HOSTS=localhost, DATABASE_URL=sqlite:/// SITE_URL= ./manage.py collectstatic --noinput
 RUN chown webdev.webdev -R .
 USER webdev
+ENV LANG=C.UTF-8


### PR DESCRIPTION
This should help with the `UnicodeEncodeError`s we've been seeing.